### PR TITLE
Remove APAC Meeting Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,9 @@ This is the starting point for joining and contributing to Symbl.ai community pr
 
 - Join the [Symbl.ai Google Group][google_group] to get Access to the Google Calendar and Agenda Document below
 - Add the [Community Calendar][google_calendar] to your Google Calendar:
-  - Americas friendly meeting will occur every [4th Wednesday at 11am PST - Zoom link](https://us02web.zoom.us/j/89036513899?pwd=TDNoUmdCNWt4RE43RGlTc0h0aS96QT09). [Convert to your timezone](https://dateful.com/convert/pst-pdt-pacific-time?t=11am)
-    - [Community Meeting and Office Hours Agenda Notes][agenda_doc]
-    - [Meeting Recordings Link](https://www.youtube.com/playlist?list=PLheDW2BRneFZOjmoSZHApW2vhedg2wiRl)
-  - Asia/Pacific friend meeting will occur in the evening after the Americas meeting [usually the 4th Thursday at 8am IST](https://us02web.zoom.us/j/86117993291?pwd=VW5ka1ZFWEpKN1JWcXRjdk5jTWRTQT09). [Convert to your timezone](https://dateful.com/convert/indian-standard-time-ist?t=8am)
-    - [Community Meeting and Office Hours Agenda Notes][agenda_doc]
-    - [Meeting Recordings Link](https://www.youtube.com/playlist?list=PLheDW2BRneFZOjmoSZHApW2vhedg2wiRl)
+- The Community Meeting will occur every [4th Wednesday at 11am PST - Zoom link](https://us02web.zoom.us/j/89036513899?pwd=TDNoUmdCNWt4RE43RGlTc0h0aS96QT09). [Convert to your timezone](https://dateful.com/convert/pst-pdt-pacific-time?t=11am)
+  - [Community Meeting Agenda and Notes][agenda_doc]
+  - [Meeting Recordings Link](https://www.youtube.com/playlist?list=PLheDW2BRneFZOjmoSZHApW2vhedg2wiRl)
 
 ## Office Hours
 


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
The proposal is to remove the APAC Community Meeting due to lack of attendance.

It's takes a lot of effort to prepare for, schedule, and be available for a meeting that historically hasn't been well attended. Since the meetings are recorded, posted to YouTube and the slides are made available to the public, the urgency or need for having two meetings significantly drops. This will also eliminate the timezone confusion that some people are having between the two meetings.

This proposal will leave a single Community Meeting that occurs on the 4th Wednesday of each month at 11am Pacific. If removing the APAC meeting causes some conflict where we need to reassess the 11am Pacific start time to accommodate Europe or Asia-Pacific, we can definitely do so. Those that would have this conflict, I would ask that you reply to this PR as to make sure all voices are heard.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
